### PR TITLE
test: Update overview raise hand test

### DIFF
--- a/bigbluebutton-tests/playwright/learningdashboard/learningdashboard.js
+++ b/bigbluebutton-tests/playwright/learningdashboard/learningdashboard.js
@@ -138,7 +138,6 @@ class LearningDashboard extends MultiUsers {
   async overview() {
     await this.modPage.waitAndClick(e.joinVideo);
     await this.modPage.waitAndClick(e.startSharingWebcam);
-    await this.modPage.waitAndClick(e.reactionsButton);
     await this.modPage.waitAndClick(e.raiseHandBtn);
 
     await this.dashboardPage.reloadPage();

--- a/bigbluebutton-tests/playwright/learningdashboard/learningdashboard.spec.js
+++ b/bigbluebutton-tests/playwright/learningdashboard/learningdashboard.spec.js
@@ -29,7 +29,7 @@ test.describe('Learning Dashboard', async () => {
   test('Basic Infos', { tag: '@ci' }, async () => {
     await learningDashboard.basicInfos();
   });
-
+  
   test('Overview', { tag: '@ci' }, async () => {
     await learningDashboard.overview();
   });

--- a/bigbluebutton-tests/playwright/notifications/notifications.spec.js
+++ b/bigbluebutton-tests/playwright/notifications/notifications.spec.js
@@ -24,7 +24,8 @@ test.describe.parallel('Notifications', { tag: '@ci' }, () => {
     await notifications.getUserJoinPopupResponse();
   });
 
-  test('Raise and lower hand notification @flaky', async ({ browser, context, page }) => {
+  //Notification does not disappear, test needs to be updated after the fix.
+  test('Raise and lower hand notification', { tag: '@flaky' }, async ({ browser, context, page }) => {
     const notifications = new Notifications(browser, context);
     await notifications.initModPage(page);
     await notifications.raiseAndLowerHandNotification();


### PR DESCRIPTION
### What does this PR do?
Updates the test overview raise hand on the the learning dashboard and adds a comment for the skipped raise hand notification test.
