### PR TITLE
test: Updates the allow multiple choices polling test

### DIFF
--- a/bigbluebutton-tests/playwright/polling/poll.js
+++ b/bigbluebutton-tests/playwright/polling/poll.js
@@ -161,8 +161,7 @@ class Polling extends MultiUsers {
     await this.modPage.waitAndClickElement(e.allowMultiple);
 
     await this.modPage.waitAndClick(e.addPollItem);
-    await this.modPage.waitAndClick(e.startPoll);
-    await this.modPage.hasElement(e.errorNoValueInput, 'should display an error after trying to start a poll without any input on the option poll item');
+    await this.modPage.hasElementDisabled(e.startPoll, 'should display the start poll button disabled');
 
     await this.modPage.type(e.pollOptionItem1, 'test1');
     await this.modPage.waitAndClick(e.addPollItem);


### PR DESCRIPTION


### What does this PR do?

Updates the "allow multiple choices" test, now the start poll button is disabled when creating a poll with one option.