### PR TITLE
test: Adds the flaky flag to the smart slides test

### DIFF
--- a/bigbluebutton-tests/playwright/polling/polling.spec.js
+++ b/bigbluebutton-tests/playwright/polling/polling.spec.js
@@ -46,7 +46,7 @@ test.describe.parallel('Polling', { tag: '@ci' }, async () => {
     await polling.allowMultipleChoices();
   });
 
-  test('Smart slides questions', async () => {
+  test('Smart slides questions', { tag: '@flaky' }, async () => {
     await polling.smartSlidesQuestions();
   });
 


### PR DESCRIPTION
### What does this PR do?
Adds the flaky flag for the smart slides tests due to some inconsistency on CI. The test is already being improved.